### PR TITLE
move for loop under if condition

### DIFF
--- a/integration.py
+++ b/integration.py
@@ -31,12 +31,12 @@ def configure_subjects(input_subjects, output_subjects):
     global OUTPUT_SUBJECTS
     if input_subjects:
         print "Input Subjects:"
-    for i in input_subjects:
-        print "\t", i
+        for i in input_subjects:
+            print "\t", i
     if output_subjects:
         print "Ouput Subjects:"
-    for i in output_subjects:
-        print "\t", i
+        for i in output_subjects:
+            print "\t", i
     INPUT_SUBJECTS = input_subjects
     OUTPUT_SUBJECTS = output_subjects
 


### PR DESCRIPTION
If the for loop sits where it is now, the container will exit with an exception if there are no input subjects or no output subjects.

```
main.py:66:configure_subjects
Traceback (most recent call last):
  File "main.py", line 64, in <module>
    configure_subjects(APP_CONFIG['input_subjects'], APP_CONFIG['output_subjects'])
  File "/app/integration.py", line 410, in configure_subjects
    for i in input_subjects:
TypeError: 'NoneType' object is not iterable
```